### PR TITLE
Don't use LSIF output value to process files.

### DIFF
--- a/lib/src/generator/lsif_generator.dart
+++ b/lib/src/generator/lsif_generator.dart
@@ -228,7 +228,7 @@ class LsifGenerator {
   LsifGenerator(this._environment, this._parsedData);
 
   bool isFileInProject(String file) {
-    return file.startsWith(_environment.config.output);
+    return file.startsWith(_environment.config.input);
   }
 
   void generate() async {
@@ -242,7 +242,7 @@ class LsifGenerator {
         "id": 'meta',
         "type": 'vertex',
         "label": 'metaData',
-        "projectRoot": "file://${_environment.config.output}",
+        "projectRoot": "file://${_environment.config.input}",
         "version": '0.4.0',
         "positionEncoding": 'utf-16',
         "toolInfo": {"name": 'crossdart', "args": [], "version": 'dev'}


### PR DESCRIPTION
Using the `--output` for any value other than `--input` will emit the metadata and then not process files because `isFileInProject` evaluates to false.

Presumably we should also be emitting the project root value in the LSIF dump using the `config.input` and not `config.output`.

I want to add tests and make sure it preserves existing behavior before merging.



