### PR TITLE
Adding status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dart LSIF indexer
+# Dart LSIF indexer ![](https://img.shields.io/badge/status-beta-orange?style=flat)
 
 Visit https://lsif.dev/ to learn about LSIF.
 


### PR DESCRIPTION
Status badge helps inform users of the state of the tool, the badge should match status listed in: https://lsif.dev/